### PR TITLE
Fetch dependencies before linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CONTAINER_NAME ?= vegeta
 
 SERVER_DIR = cmd/server
 
-all: fmt lint build test
+all: deps fmt lint build test
 
 build: deps fmt
 	CGO_ENABLED=0 go build -v -o bin/vegeta-server -a -tags=netgo \


### PR DESCRIPTION
Running `make all` as a first step after cloning the repo fails if you're missing any dependencies (say, Gin). This prepends a `deps` step to fix that.