### PR TITLE
http header cannot assign to a nil map

### DIFF
--- a/pkg/vegeta/options.go
+++ b/pkg/vegeta/options.go
@@ -51,7 +51,7 @@ func NewAttackOptsFromAttackParams(name string, params models.AttackParams) (*At
 	timeout, _ := time.ParseDuration(params.Timeout)
 
 	// Set target headers
-	var hdr http.Header
+	hdr := make(http.Header)
 	for _, h := range params.Headers {
 		hdr.Add(h.Key, h.Value)
 	}

--- a/pkg/vegeta/options_test.go
+++ b/pkg/vegeta/options_test.go
@@ -1,0 +1,66 @@
+package vegeta
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+	"vegeta-server/models"
+
+	vegeta "github.com/tsenart/vegeta/lib"
+)
+
+func TestNewAttackOptsFromAttackParams_WithHeaders(t *testing.T) {
+	tests := []struct {
+		name   string
+		params models.AttackParams
+		want   AttackOpts
+	}{
+		{"with-headers", models.AttackParams{
+			Rate:     5,
+			Duration: "10s",
+			Headers: []models.AttackHeader{
+				{
+					Key:   "X-Test-Key",
+					Value: "test-value",
+				},
+			},
+		}, AttackOpts{
+			Name:     "with-headers",
+			Duration: 10 * time.Second,
+			Rate: vegeta.Rate{
+				Freq: 5,
+				Per:  time.Second,
+			},
+			Target: vegeta.Target{
+				Header: http.Header{
+					"X-Test-Key": []string{"test-value"},
+				},
+			},
+		}},
+		{"without-headers", models.AttackParams{
+			Rate:     5,
+			Duration: "10s",
+		}, AttackOpts{
+			Name:     "without-headers",
+			Duration: 10 * time.Second,
+			Rate: vegeta.Rate{
+				Freq: 5,
+				Per:  time.Second,
+			},
+			Target: vegeta.Target{
+				Header: make(http.Header),
+			},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewAttackOptsFromAttackParams(tt.name, tt.params)
+			if !reflect.DeepEqual(got.Target.Header, tt.want.Target.Header) {
+				t.Errorf("NewAttackOptsFromAttackParams() = %v, want %v", got.Target.Header, tt.want.Target.Header)
+			} else if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Was using this to perform testing on a target where I needed to pass an AttackHeader. When I went to get the report of the attack, it returned no attack with that id could be found. I noticed the server panic'd on my systemd unit and triggered a restart. 

Wrote a test to verify that it was related to the headers.
```== RUN   TestNewAttackOptsFromAttackParams_WithHeaders
=== RUN   TestNewAttackOptsFromAttackParams_WithHeaders/with-headers
--- FAIL: TestNewAttackOptsFromAttackParams_WithHeaders (0.00s)
    --- FAIL: TestNewAttackOptsFromAttackParams_WithHeaders/with-headers (0.00s)
panic: assignment to entry in nil map [recovered]
        panic: assignment to entry in nil map

goroutine 28 [running]:
testing.tRunner.func1.1(0x8f2900, 0x9e45a0)
        /snap/go/6274/src/testing/testing.go:988 +0x452
testing.tRunner.func1(0xc0000df560)
        /snap/go/6274/src/testing/testing.go:991 +0x600
panic(0x8f2900, 0x9e45a0)
        /snap/go/6274/src/runtime/panic.go:975 +0x3e3
net/textproto.MIMEHeader.Add(...)
        /snap/go/6274/src/net/textproto/header.go:15
net/http.Header.Add(...)
        /snap/go/6274/src/net/http/header.go:28
vegeta-server/pkg/vegeta.NewAttackOptsFromAttackParams(0x95d57d, 0xc, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /home/allee/go/src/github.com/vegeta-server/pkg/vegeta/options.go:56 +0x2b6
vegeta-server/pkg/vegeta.TestNewAttackOptsFromAttackParams_WithHeaders.func1(0xc0000df560)
        /home/allee/go/src/github.com/vegeta-server/pkg/vegeta/options_test.go:58 +0x106
testing.tRunner(0xc0000df560, 0xc0001245c0)
        /snap/go/6274/src/testing/testing.go:1039 +0x1ec
created by testing.(*T).Run
        /snap/go/6274/src/testing/testing.go:1090 +0x701
FAIL    vegeta-server/pkg/vegeta        0.017s
FAIL
make: *** [Makefile:32: test] Error 1```

Made changes to options. Ran make test and passed