### PR TITLE
unknown long flag '--scheme', try --help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ineffassign:
 	ineffassign .
 
 run: build
-	$(shell bin/vegeta-server --scheme=http --host=localhost --port=8000)
+	$(shell bin/vegeta-server --ip=localhost --port=8000)
 
 container:
 	docker build -t vegeta-server:latest .


### PR DESCRIPTION
Was testing out the project and making changes. Noticed I couldn't run the server from the make file. The output showed

```bin/vegeta-server --scheme=http --host=localhost --port=8000
vegeta-server: error: unknown long flag '--scheme', try --help```

This reflects what is in master